### PR TITLE
Drops request function and adds json decoding to post

### DIFF
--- a/test/signals/sources/xhr.js
+++ b/test/signals/sources/xhr.js
@@ -13,7 +13,7 @@ test('request: when is successful', (assert) => {
 
   let newRequest = request(next, error)
 
-  assert.equal(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+  assert.deepEqual(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
 
   newRequest.onload()
   assert.ok(next.called, 'calls next callback when request is successful')
@@ -33,7 +33,7 @@ test('request: when it fails', (assert) => {
 
   let newRequest = request(next, error)
 
-  assert.equal(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+  assert.deepEqual(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
 
   newRequest.onload()
   assert.notOk(next.called, 'never calls next when request fails')

--- a/test/signals/sources/xhr.js
+++ b/test/signals/sources/xhr.js
@@ -1,0 +1,43 @@
+import test from 'tape'
+import { request } from '../../../signals/sources/xhr'
+import { spy } from 'sinon'
+
+test('request: when is successful', (assert) => {
+  const next = spy()
+  const error = spy()
+
+  const fakeRequest = {status: 200}
+  global.XMLHttpRequest = () => {
+    return fakeRequest
+  }
+
+  let newRequest = request(next, error)
+
+  assert.equal(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+
+  newRequest.onload()
+  assert.ok(next.called, 'calls next callback when request is successful')
+  assert.notOk(error.called, 'never calls error when request is successful')
+
+  assert.end()
+})
+
+test('request: when it fails', (assert) => {
+  const next = spy()
+  const error = spy()
+
+  const fakeRequest = {status: 404}
+  global.XMLHttpRequest = () => {
+    return fakeRequest
+  }
+
+  let newRequest = request(next, error)
+
+  assert.equal(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+
+  newRequest.onload()
+  assert.notOk(next.called, 'never calls next when request fails')
+  assert.ok(error.called, 'calls error callback when request fails')
+
+  assert.end()
+})

--- a/test/signals/sources/xhr.js
+++ b/test/signals/sources/xhr.js
@@ -1,43 +1,54 @@
 import test from 'tape'
-import { request } from '../../../signals/sources/xhr'
+import { getJSON } from '../../../signals/sources/xhr'
 import { spy } from 'sinon'
 
-test('request: when is successful', (assert) => {
+test('getJSON: when is successful', (assert) => {
   const next = spy()
   const error = spy()
 
-  const fakeRequest = {status: 200}
+  const fakeRequest = {
+    status: 200,
+    responseText: '{}',
+    open: spy(),
+    send: spy()
+  }
+
   global.XMLHttpRequest = () => {
     return fakeRequest
   }
 
-  let newRequest = request(next, error)
+  let newRequest = getJSON('/')(next, error)
 
-  assert.deepEqual(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+  assert.deepEqual(newRequest, fakeRequest, 'getJSON returns new XMLHttpRequest')
 
   newRequest.onload()
   assert.ok(next.called, 'calls next callback when request is successful')
   assert.notOk(error.called, 'never calls error when request is successful')
+  assert.ok(fakeRequest.open, 'calls request.open')
+  assert.ok(fakeRequest.send, 'calls request.send')
 
   assert.end()
 })
 
-test('request: when it fails', (assert) => {
+test('getJSON: when it fails', (assert) => {
   const next = spy()
   const error = spy()
 
-  const fakeRequest = {status: 404}
+  const fakeRequest = {status: 404, open: spy(), send: spy()}
+
   global.XMLHttpRequest = () => {
     return fakeRequest
   }
 
-  let newRequest = request(next, error)
+  let newRequest = getJSON('/')(next, error)
 
-  assert.deepEqual(newRequest, fakeRequest, 'request returns new XMLHttpRequest')
+  assert.deepEqual(newRequest, fakeRequest, 'getJSON returns new XMLHttpRequest')
 
   newRequest.onload()
   assert.notOk(next.called, 'never calls next when request fails')
   assert.ok(error.called, 'calls error callback when request fails')
+  assert.ok(fakeRequest.open, 'calls request.open')
+  assert.ok(fakeRequest.send, 'calls request.send')
 
   assert.end()
 })


### PR DESCRIPTION
* Drop the `request` function, I think it is too low level to be exposed here.
* Decomposed `get`, `getJSON` and `post` into smaller functions.
* Adds the JSON decoding to the response of `post`
* Add getJSON test

Another upshot here is that the exported functions got smaller and more functionality was moved to private functions.